### PR TITLE
Fix responsiveness on dash board mobile

### DIFF
--- a/cssfiles/dashboardhome.css
+++ b/cssfiles/dashboardhome.css
@@ -626,8 +626,10 @@ padding: 30px 10px;
 	}
 
 	#content {
+      position: absolute;
+      left: 60px;
 		width: calc(100% - 60px);
-		left: 200px;
+		left: 60px;
 	}
 
 	#content nav .nav-link {

--- a/cssfiles/dashboardhome.css
+++ b/cssfiles/dashboardhome.css
@@ -219,7 +219,8 @@ body {
 	position: sticky;
 	top: 0;
 	left: 0;
-	z-index: 1000;
+   z-index: 2001;
+   padding-left: 0;
 }
 #content nav::before {
 	content: '';

--- a/cssfiles/dashboardhome.css
+++ b/cssfiles/dashboardhome.css
@@ -323,10 +323,11 @@ body {
 	color: #fff;
 }
 #content main .head-title .left h1 {
-	font-size: 36px;
+	font-size: 28px;
 	font-weight: 600;
 	margin-bottom: 5px;
-	color: #fff;;
+	color: #fff;
+   overflow-wrap: anywhere;
 }
 #content main .head-title .left .breadcrumb {
 	display: flex;

--- a/cssfiles/dashboardhome.css
+++ b/cssfiles/dashboardhome.css
@@ -621,7 +621,8 @@ padding: 30px 10px;
 
 @media screen and (max-width: 768px) {
 	#sidebar {
-		width: 200px;
+		width: 100%;
+      max-width: 375px;
 	}
 
 	#content {

--- a/htmlfiles/dashboardhome.html
+++ b/htmlfiles/dashboardhome.html
@@ -24,9 +24,9 @@
 
 
 	<!-- SIDEBAR -->
-	<section id="sidebar">
+	<section id="sidebar" class="hide">
 		
-  <div id="student-img"> 
+  <div id="student-img" class="remove"> 
 	
 
   </div>

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -353,3 +353,19 @@ const logout = ()=>{
  `
 
 }
+
+// function to close side bar when any of the side bar menu is clicked 
+const [SIDEBAR_LIST1, SIDEBAR_LIST2] = document.querySelectorAll('.side-menu');
+const SIDEBAR_ITEM1 = SIDEBAR_LIST1.querySelectorAll(':scope > li');
+const SIDEBAR_ITEM2 = SIDEBAR_LIST2.querySelectorAll(':scope > li');
+const sidebarList = [...SIDEBAR_ITEM1, ...SIDEBAR_ITEM2];
+
+const sidebarClickHandler = () => {
+   for (const item of sidebarList) {
+      item.addEventListener('click', () => {
+         sidebar.classList.add('hide');
+			studentImage.classList.add('remove');
+      } )
+   }
+}
+sidebarClickHandler();


### PR DESCRIPTION
## Problem statement 1
![image](https://user-images.githubusercontent.com/67319772/185335361-431a2d41-4f5f-4293-80fb-9c7417968d1d.png)
## Solution
This was fixed by making the sidebar slide in as an overlay 

![ezgif com-gif-maker](https://user-images.githubusercontent.com/67319772/185339081-2c2d6918-e984-4fff-aec0-936bd94f1106.gif)

## Problem statement 2
Overflow on user name 
![image](https://user-images.githubusercontent.com/67319772/185339628-747fe2c3-c4c0-4f8d-8395-f3bc524dad1c.png)
## Solution
Reduce font sizes and set text overflow to wrap
![image](https://user-images.githubusercontent.com/67319772/185340114-011ae1c2-fcb5-403f-a9b0-e284d45954a6.png)

## Additional Feature
create Js function to close the side bar overlay anytime a side bar menu is clicked

