### PR TITLE
Resize Pop Up Menu layout

### DIFF
--- a/cssfiles/dashboardhome.css
+++ b/cssfiles/dashboardhome.css
@@ -591,13 +591,16 @@ aside p{
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	height: 70vh;
-	background: var(--light);
-	border-radius: 20px;
+	height: 80vh;
+	text-align: center;
+	font-size: min(3vw, 15px);
 }
 
-.parent-logout div{
+.parent-logout > div {
+	border-radius: 20px;
 	background: var(--light);
+	height: min(12em, 40vw);
+	width: min(25em, 70vw);
 	display: flex;
 	flex-direction:column;
 	justify-content: center;
@@ -608,13 +611,31 @@ aside p{
 .parent-logout .links{
 	display: flex;
 	justify-content: space-between;
+	width: max(50%, 10em);
 }
+
 .parent-logout .links a{
 	text-decoration: none;
 	cursor: pointer;
 	text-transform: uppercase;
+	padding: 5px 10px;
+	border-radius: 20px;
+	width: 4em;
+	margin-top: 15px;
+	color: white;
+	transition: filter 0.15s ease;
+	font-weight: 500;
 }
 
+.parent-logout .links #yes-link {
+	background-color: rgb(224, 28, 28);
+}
+.parent-logout .links #no-link {
+	background-color: rgb(59, 194, 59);
+}
+.parent-logout .links #yes-link:hover, .parent-logout .links #no-link:hover {
+	filter: brightness(120%);
+}
 
 
 

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -337,16 +337,18 @@ const storeCircle = async () =>{
 
 const logout = ()=>{
 
+	container.classList.remove("container-style");
+	
  container.innerHTML = `
-    <div class = "parent-logout">
+	 <div class = "parent-logout">
 
 	<div>
          <h2> Are you sure you want to go back home </h2>
 
 		 <div class="links">
-            <a href ="members.html">Yes</a>
+			 <a id ="yes-link" href ="members.html">Yes</a>
 
-			<a href ="">No</a>
+			 <a id ="no-link" href ="">No</a>
 		 </div>
 		 </div>
 	</div>


### PR DESCRIPTION
Fixes #116 

### Changes made:

- made pop up menu layout smaller and in the center.
- made yes and no look like buttons with respective green and red background colors.

### The design before: 
![186218681-39e5a2c3-4acc-4773-a540-8c475399d1f2](https://user-images.githubusercontent.com/107622593/186695368-87c6d8f8-8bc7-47f4-9d3a-7df0f326b7f5.png)
### After:
![popUpMenu](https://user-images.githubusercontent.com/107622593/186695716-24c2667b-65af-493b-bef7-99c1966c8ea6.png)

